### PR TITLE
[Feature] Updated home concerts layout

### DIFF
--- a/src/domain/models/Show.ts
+++ b/src/domain/models/Show.ts
@@ -11,6 +11,7 @@ export type ShowType = {
     updatedAt: string,
     title: string,
     description: string
+    logo: string
   }
   songs: {
     id: string,

--- a/src/presentation/ui/views/home/elements/show.tsx
+++ b/src/presentation/ui/views/home/elements/show.tsx
@@ -17,11 +17,13 @@ export const ShowItem: FC<{
   title: string,
   band: string,
   date: string,
+  logo: string,
   onClick?: () => void
 }> = ({
   title,
   band,
   date,
+  logo,
   onClick = () => {}
 }) => {
   // Color Hooks
@@ -43,33 +45,36 @@ export const ShowItem: FC<{
         opacity: "0.8"
       }}
     >
-      <Badge
-        variant="outline"
-        colorScheme="gray"
-        color="white"
-        transition="all 0.3s"
-        position="absolute"
-        top="1.5"
-        right="1.5"
-      >
-        { date.split('T')[0].split('-').reverse().join('/') }
-      </Badge>
       <Box
-        minHeight="128px"
+        minHeight="64px"
         bgGradient="linear(to-b, secondary.600, primary.600)"
         borderTopRadius="lg"
+        mb="6"
       >
+        
         <Flex
           justifyContent="center"
           alignItems="center"
-          pt="6"
+          pt="2"
         >
+          <Badge
+            variant="outline"
+            colorScheme="gray"
+            color="white"
+            transition="all 0.3s"
+            rounded="md"
+          >
+            { date.split('T')[0].split('-').reverse().join('/') }
+          </Badge>
           <Image 
-            src="/img/arts/white/concert.svg"
+            src={logo}
             alt="Concert image"
-            width="96px"
-            height="96px"
+            width="56px"
+            height="56px"
+            rounded="full"
             objectFit="cover"
+            position="absolute"
+            top="36px"
           />
         </Flex>
       </Box>

--- a/src/presentation/ui/views/home/index.tsx
+++ b/src/presentation/ui/views/home/index.tsx
@@ -83,6 +83,7 @@ const HomeView: FC = () => {
                   title={show.title}
                   band={show.band.title}
                   date={show.date}
+                  logo={show.band.logo}
                   onClick={() => router.push(`/shows/${show.id}`)}
                 /> 
               ))}


### PR DESCRIPTION
# Description

Updated home concerts layout to display band logo.

## Changes

* Added band logo and centralized on concert item included in home screen.

## Screenshots

![image](https://github.com/Mazurco066/playliter-pwa-next/assets/26048377/74eabea2-7363-4a97-9908-2aa13f19be73)
