### PR TITLE
feat(concert): added clone concert feature to frontend

### DIFF
--- a/public/locales/en/concert.json
+++ b/public/locales/en/concert.json
@@ -7,7 +7,13 @@
   "notes_drawer": "Concert notes",
   "reorder_drawer": "Reorder songs",
   "add_drawer": "Add songs",
+  "clone_modal": {
+    "title": "Clone concert",
+    "cancel_action": "Cancel",
+    "confirm_action": "Confirm"
+  },
   "menu": {
+    "clone": "Duplicate",
     "edit": "Edit",
     "reorder": "Reorder concert",
     "remove": "Remove concert"
@@ -101,6 +107,8 @@
     "added_to_show_title": "Success!",
     "added_to_show_msg": "The selected song was successfuly added to concert!",
     "song_present_title": "Ops.. Song already present!",
-    "song_present_msg": "This song is already present in the selected concert!"
+    "song_present_msg": "This song is already present in the selected concert!",
+    "clone_concert_title": "Success!",
+    "clone_concert_msg": "This concert was successfully duplicated to your desired date."
   }
 }

--- a/public/locales/pt/concert.json
+++ b/public/locales/pt/concert.json
@@ -7,7 +7,13 @@
   "notes_drawer": "Anotações da apresentação",
   "reorder_drawer": "Reordenar músicas",
   "add_drawer": "Adicionar músicas",
+  "clone_modal": {
+    "title": "Duplicar apresentação",
+    "cancel_action": "Cancelar",
+    "confirm_action": "Confirmar"
+  },
   "menu": {
+    "clone": "Clonar",
     "edit": "Editar",
     "reorder": "Reordenar músicas",
     "remove": "Remover apresentação"
@@ -101,6 +107,8 @@
     "added_to_show_title": "Sucesso!",
     "added_to_show_msg": "A música selecionada foi adicionada na apresentação!",
     "song_present_title": "Ops.. Música já se encontra presente!",
-    "song_present_msg": "A música solicitada já se encontra presenta na apresentação escolhida!"
+    "song_present_msg": "A música solicitada já se encontra presenta na apresentação escolhida!",
+    "clone_concert_title": "Sucesso!",
+    "clone_concert_msg": "A apresentação foi duplicada para a data desejada!"
   }
 }

--- a/src/pages/api/shows/clone_concert.ts
+++ b/src/pages/api/shows/clone_concert.ts
@@ -1,0 +1,43 @@
+// Dependencies
+import { withIronSessionApiRoute } from 'iron-session/next'
+import { sessionOptions } from 'infra/services/session'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { requestApi } from 'infra/services/http'
+
+// Types
+import type { ShowType } from 'domain/models'
+
+// Clone show endpoint
+async function cloneConcetRoute(req: NextApiRequest, res: NextApiResponse) {
+  if (req.session.user) {
+    // Retrieve parameters
+    const { id, date } = req.body
+
+    // Request concert cloning endpoint
+    const response = await requestApi(`/shows/${id}`, 'post', { date }, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${req.session.user?.token}`
+      }
+    })
+
+    // Verify if request was sucessfull
+    if (response.status < 400) {
+      // Returns updated band
+      const { data } = response.data
+      res.status(200).json(data as ShowType)
+
+    } else {
+      return res.status(response.status).json(response.data)
+    }
+
+  } else {
+    res.status(401).json({ message: 'Unauthorized' })
+  }
+}
+
+// Exporting service
+export default withIronSessionApiRoute(
+  cloneConcetRoute,
+  sessionOptions
+)

--- a/src/presentation/ui/views/show/elements/clone-modal.tsx
+++ b/src/presentation/ui/views/show/elements/clone-modal.tsx
@@ -1,0 +1,118 @@
+// Dependencies
+import { FC } from 'react'
+import { useTranslation } from 'next-i18next'
+import { useForm } from 'react-hook-form'
+
+// Components
+import { FaCalendar } from 'react-icons/fa'
+import {
+  Button,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Icon,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react'
+
+// Component
+export const CloneConcertModal: FC<{
+  isOpen: boolean,
+  onOpen: () => void,
+  onClose: () => void,
+  isLoading?: boolean,
+  onConfirmCallback?: (date: string) => void
+}> = ({
+  isOpen,
+  onClose,
+  isLoading = false,
+  onConfirmCallback = () => {}
+}) => {
+    // Hooks
+    const { t } = useTranslation('concert')
+    const {
+      register,
+      handleSubmit,
+      formState: { errors },
+    } = useForm()
+
+    // Actions
+    const onSubmit = async (data: any) => {
+      onConfirmCallback(data.date)
+    }
+
+    // JSX
+    return (
+      <Modal
+        size="sm"
+        isOpen={isOpen}
+        onClose={onClose}
+        closeOnOverlayClick={false}
+      >
+        <ModalOverlay />
+        <ModalContent
+          mx="4"
+        >
+          <ModalHeader>
+            {t('clone_modal.title')}
+          </ModalHeader>
+          <ModalCloseButton
+            isDisabled={isLoading}
+          />
+          <ModalBody>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <FormControl
+                isDisabled={isLoading}
+                isRequired
+                mb="5"
+              >
+                <FormLabel>{t('save.date_label')}</FormLabel>
+                <InputGroup>
+                  <InputLeftElement
+                    pointerEvents="none"
+                    children={<Icon as={FaCalendar} />}
+                  />
+                  <Input
+                    disabled={isLoading}
+                    variant="filled"
+                    type="date"
+                    {...register('date', { required: true })}
+                  />
+                </InputGroup>
+                {errors.date ? (
+                  <FormHelperText color="red.500">{t('save.required_field')}</FormHelperText>
+                ) : (
+                  <FormHelperText>{t('save.date_hint')}</FormHelperText>
+                )}
+              </FormControl>
+            </form>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              colorScheme="red"
+              mr={3}
+              onClick={onClose}
+              isDisabled={isLoading}
+            >
+              {t('clone_modal.cancel_action')}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleSubmit(onSubmit)}
+              isDisabled={isLoading}
+            >
+              {t('clone_modal.confirm_action')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    )
+  }

--- a/src/presentation/ui/views/show/elements/index.ts
+++ b/src/presentation/ui/views/show/elements/index.ts
@@ -1,3 +1,4 @@
+export * from './clone-modal'
 export * from './drawer'
 export * from './note-form'
 export * from './notes'


### PR DESCRIPTION
# Description

Added clone concert feature according to [Issue](https://github.com/Mazurco066/playliter-pwa-next/issues/13)

## Screenshots

* Added duplicate button to concert options

![image](https://github.com/Mazurco066/playliter-pwa-next/assets/26048377/5c5d494a-14d5-4ab2-95e2-d39f1ec5afa9)

* When clicked it will display a dialog asking for the day you desire to duplicate the concert:

![image](https://github.com/Mazurco066/playliter-pwa-next/assets/26048377/909b6fc6-d5a0-4f3d-93c3-cb688bba8580)

## Changes

* Just added the duplicate button and dialog to concert screen details page.